### PR TITLE
Investigate logs.php system error

### DIFF
--- a/admin/logs.php
+++ b/admin/logs.php
@@ -60,7 +60,7 @@ $logs = $db->fetchAll(
     "SELECT ol.*, a.username, a.real_name,
             DATE_FORMAT(ol.created_at, '%Y-%m-%d %H:%i:%s') as created_time
      FROM operation_logs ol 
-     LEFT JOIN admins a ON ol.admin_id = a.id 
+     LEFT JOIN admins a ON ol.operator_type = 'admin' AND ol.operator_id = a.id 
      WHERE {$where} 
      ORDER BY ol.created_at DESC 
      LIMIT ? OFFSET ?",
@@ -69,7 +69,7 @@ $logs = $db->fetchAll(
 
 // 获取总数
 $total = $db->fetchOne(
-    "SELECT COUNT(*) as count FROM operation_logs ol LEFT JOIN admins a ON ol.admin_id = a.id WHERE {$where}",
+    "SELECT COUNT(*) as count FROM operation_logs ol LEFT JOIN admins a ON ol.operator_type = 'admin' AND ol.operator_id = a.id WHERE {$where}",
     $params
 )['count'];
 
@@ -314,8 +314,8 @@ $actionStats = $db->fetchAll(
                                             <code class="small"><?php echo htmlspecialchars($log['ip_address']); ?></code>
                                         </td>
                                         <td>
-                                            <?php if ($log['related_id']): ?>
-                                            <span class="badge bg-light text-dark">#<?php echo $log['related_id']; ?></span>
+                                            <?php if ($log['target_id']): ?>
+                                            <span class="badge bg-light text-dark">#<?php echo $log['target_id']; ?></span>
                                             <?php else: ?>
                                             <span class="text-muted">-</span>
                                             <?php endif; ?>


### PR DESCRIPTION
Fix SQL query and field reference in `admin/logs.php` to resolve system errors.

The original `admin/logs.php` caused a system error due to incorrect SQL joins and field references. The `operation_logs` table uses `operator_id` and `operator_type` for linking to admins, not `admin_id`. Additionally, `related_id` was incorrectly used instead of `target_id`. This PR corrects these discrepancies to ensure the logs page functions correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d585c0f-2340-4987-a435-b6772c76b0d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d585c0f-2340-4987-a435-b6772c76b0d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

